### PR TITLE
Dev/i2c checks and scanner

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RocciBoard-Library
-version=1.4.2
+version=1.4.3
 author=Robotics Competence Center Illertal e. V. <rocci.net>
 maintainer=Jonas Biener <jonas.biener@rocci.net>, Alexander Ulbrich <alexander.ulbrich@rocci.net>
 sentence=Library for the RocciBoard-Shield.

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -41,6 +41,15 @@ void RocciBoard::init (void)
     motor[1].init();
     motor[2].init();
     motor[3].init();
+    // test i2c port
+    if( ! testI2CPort() )
+    {
+        Serial.println(" am Rocciboard I2C. Pin D21 oder D22 belegt?");
+        while(1)
+        {
+            blinkDebugLED();
+        }
+    }
     // Initializing I2C-Multiplexer
     pinMode(RB_MUX_RESET, INPUT_PULLUP);
     tca_.begin(Wire);
@@ -62,6 +71,25 @@ void RocciBoard::closeSensorPort (uint8_t sensor_port)
 void RocciBoard::closeAllSensorPorts (void)
 {
     tca_.closeAll();
+}
+
+bool RocciBoard::testI2CPort(bool with_debug = true)
+{
+    pinMode(RB_I2C_SCL, INPUT);
+    pinMode(RB_I2C_SDA, INPUT);
+    if(digitalRead(RB_I2C_SCL) == 0) 
+    {
+        if(with_debug) Serial.print("SCL Fehler");
+        return false;
+    }
+    if(digitalRead(RB_I2C_SDA) == 0)
+    {
+        if(with_debug) Serial.print("SDA Fehler");
+        return false;
+    } 
+    pinMode(RB_I2C_SCL, OUTPUT);
+    pinMode(RB_I2C_SDA, INPUT);
+    return true;
 }
 
 void RocciBoard::resetMultiplexer (void)

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -51,7 +51,31 @@ void RocciBoard::init (void)
         }
     }
     // Initializing I2C-Multiplexer
-    pinMode(RB_MUX_RESET, INPUT_PULLUP);
+    resetMultiplexer(); // reset to make sure nothing is still open
+    Wire.begin();
+
+    //verify TCA is connected with correct address
+    Wire.beginTransmission(tca_addr);
+    int error = Wire.endTransmission();
+    if(error)
+    {
+        Serial.println("Multiplexer Addresse ist Falsch.");
+        for(int i2c_addr = 112; i2c_addr < 120; i2c_addr++)
+        {            
+            Wire.beginTransmission(i2c_addr);
+            int error = Wire.endTransmission();
+            if (error == 0)
+            {
+                Serial.println("verwende: RocciBoard rb("+String(i2c_addr)+")");
+            }
+        }
+        while(1)
+        {
+            blinkDebugLED();
+            delay(1000);
+        }
+    }
+
     tca_.begin(Wire);
     tca_.closeAll();
     // Blink debug-LED to signal finished bootup

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -77,7 +77,23 @@ void RocciBoard::init (void)
     }
 
     tca_.begin(Wire);
-    tca_.closeAll();
+
+    //test multiplexer i2c ports
+    for(int sensor_port = 0; sensor_port < 8; sensor_port++)
+    {
+        openSensorPort(sensor_port); 
+        if( ! testI2CPort() )
+        {
+            Serial.println(" am I2C Port "+String(sensor_port)+". Kabel oder Sensor defekt?");
+            while(1)
+            {
+                blinkDebugLED();
+                delay(1000);
+            }
+        }
+        resetMultiplexer(); // reset instead of close to avoid stuck at
+    }
+
     // Blink debug-LED to signal finished bootup
     blinkDebugLED();
 }

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -21,6 +21,13 @@ void RocciBoard::init (void)
     digitalWrite(RB_DEBUG_LED, LOW);
     // Initializing the voltage-reading ADC
     pinMode(RB_BATTERY_ADC, INPUT);
+    float u_bat = getBatteryVoltage();
+    if(u_bat < 6.0)
+    {
+        Serial.println("Batteriespannung "+String(u_bat)+"V. Muss über 6V sein");
+        while(1);
+    }
+
     // Changing motor PWM frequency
     #if defined(__AVR_ATmega2560__)
         // Arduino Mega: set PWM frequency to 31372.55 Hz

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -136,8 +136,9 @@ void RocciBoard::resetMultiplexer (void)
 {
     pinMode(RB_MUX_RESET, OUTPUT);
     digitalWrite(RB_MUX_RESET, LOW);
-    delay(500);
+    delay(1);
     pinMode(RB_MUX_RESET, INPUT_PULLUP);
+    delay(1);
 }
 
 void RocciBoard::initRBSensor (RBSensor &sensor)

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -100,4 +100,27 @@ void RocciBoard::blinkDebugLED (void)
     digitalWrite(RB_DEBUG_LED, HIGH);
     delay(100);
     digitalWrite(RB_DEBUG_LED, LOW);
+
+void RocciBoard::scanI2C(void)
+{
+    Serial.println("Start I2C Scan");
+    for(int sensor_port = 0; sensor_port < 8; sensor_port++)
+    {
+        openSensorPort(sensor_port); 
+        for(int i2c_addr = 1; i2c_addr < 128; i2c_addr++)
+        {            
+            Wire.beginTransmission(i2c_addr);
+            int error = Wire.endTransmission();
+            if(i2c_addr == tca_addr) //skip multiplexer
+            {
+                continue;
+            }
+            if (error == 0)
+            {
+                Serial.println("Port:"+String(sensor_port)+" Addresse:"+String(i2c_addr));
+            }
+        }
+        closeSensorPort(sensor_port);
+    }
+    Serial.println("Ende");
 }

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -25,7 +25,11 @@ void RocciBoard::init (void)
     if(u_bat < 6.0)
     {
         Serial.println("Batteriespannung "+String(u_bat)+"V. Muss über 6V sein");
-        while(1);
+        while(1)
+        {
+            blinkDebugLED();
+            delay(1000);
+        }
     }
 
     // Changing motor PWM frequency
@@ -48,6 +52,7 @@ void RocciBoard::init (void)
         while(1)
         {
             blinkDebugLED();
+            delay(1000);
         }
     }
     // Initializing I2C-Multiplexer

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -176,6 +176,7 @@ void RocciBoard::blinkDebugLED (void)
     digitalWrite(RB_DEBUG_LED, HIGH);
     delay(100);
     digitalWrite(RB_DEBUG_LED, LOW);
+}
 
 void RocciBoard::scanI2C(void)
 {

--- a/src/rocciboard.cpp
+++ b/src/rocciboard.cpp
@@ -7,6 +7,7 @@
 
 RocciBoard::RocciBoard (uint8_t addr) : tca_(addr)
 {
+    tca_addr = addr;
     motor[0] = RBMotor(5,6);
     motor[1] = RBMotor(7,8);
     motor[2] = RBMotor(9,10);

--- a/src/rocciboard.h
+++ b/src/rocciboard.h
@@ -108,6 +108,7 @@ class RocciBoard {
 
   private:
     TCA9548A tca_;   
+    uint8_t tca_addr;
 
 };
 

--- a/src/rocciboard.h
+++ b/src/rocciboard.h
@@ -104,6 +104,11 @@ class RocciBoard {
     */ 
     void blinkDebugLED (void); 
 
+    /**
+     * Scan the i2c ports for connected devices
+     */
+    void scanI2C(void);
+
     RBMotor motor[4];
 
   private:

--- a/src/rocciboard.h
+++ b/src/rocciboard.h
@@ -34,6 +34,8 @@
 #define RB_DEBUG_LED 13
 #define RB_BATTERY_ADC A0
 #define RB_MUX_RESET 4
+#define RB_I2C_SCL 21
+#define RB_I2C_SDA 20
 
 /**
  * Hardware specific class that implements the functions of the RocciBoard-Shield. \n
@@ -53,6 +55,11 @@ class RocciBoard {
      * @return bool : Initialization successful
     */
     void init (void);
+
+    /**
+     * verifies if SCL or SDA is stuck on GND
+     */
+    bool testI2CPort(bool with_debug = true);
 
     /**
      * Opens a sensor-channel on the I²C-Multiplexer. \n 


### PR DESCRIPTION

 - i2c scanner
 - teste SCL und SDA Kurzschluss zu GND beim init
 - teste Multiplexer Adresse beim init
 - teste Spannung beim init
 - teste jeden I2C port auf Kurzschluss zu GND

Fehler werden über den Serial Monitor ausgegeben und die rote LED blinkt 